### PR TITLE
Fix over time charts

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -6,7 +6,8 @@
 #' @noRd
 app_server <- function(input, output, session, data) {
   if (is.null(data)) {
-    data <- utils::read.csv("~/Google Drive/My Drive/data_science_project_work/microsoft/project_work/624_ai_landscape_refresh/data/624_topic_df.csv", ) %>%
+    data <- utils::read.csv("~/Google Drive/My Drive/data_science_project_work/microsoft/project_work/624_ai_landscape_refresh/data/624_topic_df.csv") %>%
+      stats::na.omit() %>%
       dplyr::select(-cluster) %>%
       dplyr::rename(cluster = topic) %>%
       dplyr::mutate(date = as.Date(date)) %>%
@@ -37,8 +38,8 @@ app_server <- function(input, output, session, data) {
     global_group_var = "cluster",
     global_subgroups = NULL)
 
-  r$date_min <- min(data$date)
-  r$date_max <- max(data$date)
+  r$date_min <- min(data$date, na.rm = TRUE)
+  r$date_max <- max(data$date, na.rm = TRUE)
 
 
   mod_conversation_landscape_server("landscapeTag",
@@ -50,7 +51,8 @@ app_server <- function(input, output, session, data) {
 
   mod_distribution_tab_server(
     id = "distributionTag",
-    highlighted_dataframe = df_filtered
+    highlighted_dataframe = df_filtered,
+    r = r
   )
 
   mod_bigram_network_server("bigramTag",

--- a/R/mod_daterange_input.R
+++ b/R/mod_daterange_input.R
@@ -1,0 +1,66 @@
+#' daterange_input UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_daterange_input_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    shiny::dateRangeInput(
+      inputId = ns("dateRange"),
+      label = "date range",
+      start = NULL,
+      end = NULL,
+      min = Sys.Date() - (365* 5),
+      max = Sys.Date() + 1
+    )
+  )
+}
+
+#' daterange_input Server Functions
+#'
+#' @noRd
+mod_daterange_input_server <- function(id, highlighted_dataframe, r){
+  moduleServer( id, function(input, output, session){
+    ns <- session$ns
+
+    observeEvent(highlighted_dataframe(), {
+
+      req(!is.null(r$date_min), !is.null(r$date_max))
+
+      print(paste0("before update:", input$dateRange))
+      shiny::updateDateRangeInput(
+        session = session,
+        inputId = "dateRange",
+        start = r$date_min,
+        end = r$date_max,
+        min = r$date_min - 1,
+        max = r$date_max + 1
+      )
+      print(paste0("After update:", input$dateRange))
+
+    })
+
+    over_time_data <- reactive({
+      over_time_data <- highlighted_dataframe() %>%
+      dplyr::mutate(date = as.Date(date)) %>%
+      dplyr::filter(
+        date >= input$dateRange[[1]],
+        date <= input$dateRange[[2]])
+    })
+
+    return(list(over_time_data = over_time_data))
+
+
+  })
+}
+
+## To be copied in the UI
+# mod_daterange_input_ui("daterange_input_1")
+
+## To be copied in the server
+# mod_daterange_input_server("daterange_input_1")

--- a/R/mod_daterange_input.R
+++ b/R/mod_daterange_input.R
@@ -29,10 +29,7 @@ mod_daterange_input_server <- function(id, highlighted_dataframe, r){
     ns <- session$ns
 
     observeEvent(highlighted_dataframe(), {
-
       req(!is.null(r$date_min), !is.null(r$date_max))
-
-      print(paste0("before update:", input$dateRange))
       shiny::updateDateRangeInput(
         session = session,
         inputId = "dateRange",
@@ -41,8 +38,6 @@ mod_daterange_input_server <- function(id, highlighted_dataframe, r){
         min = r$date_min - 1,
         max = r$date_max + 1
       )
-      print(paste0("After update:", input$dateRange))
-
     })
 
     over_time_data <- reactive({

--- a/R/mod_distribution_tab.R
+++ b/R/mod_distribution_tab.R
@@ -95,17 +95,17 @@ mod_distribution_tab_ui <- function(id, distribution_tab_height, distribution_ta
 #' distribution_tab Server Functions
 #'
 #' @noRd
-mod_distribution_tab_server <- function(id, highlighted_dataframe) {
+mod_distribution_tab_server <- function(id, highlighted_dataframe, r) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
-    mod_volume_over_time_server(id = "volumeModule", highlighted_dataframe = highlighted_dataframe)
+    mod_volume_over_time_server(id = "volumeModule", highlighted_dataframe = highlighted_dataframe, r = r)
 
     mod_sentiment_server("sentimentModule", highlighted_dataframe = highlighted_dataframe)
 
     mod_token_plot_server("tokenModule", highlighted_dataframe = highlighted_dataframe)
 
-    mod_sent_time_server("sentTimeModule", highlighted_dataframe = highlighted_dataframe)
+    mod_sent_time_server("sentTimeModule", highlighted_dataframe = highlighted_dataframe, r = r)
   })
 }
 

--- a/R/mod_group_vol_time.R
+++ b/R/mod_group_vol_time.R
@@ -30,12 +30,7 @@ mod_group_vol_time_ui <- function(id) {
               title = "Parameters",
               icon = shiny::icon("wrench"),
               value = "nested1item2",
-              shiny::dateRangeInput(
-                inputId = ns("dateRangeGroupVol"),
-                label = "date range",
-                start = NULL,
-                end = NULL
-              ),
+              mod_daterange_input_ui(ns("dateRangeGroupVol")),
               shiny::selectInput(
                 inputId = ns("dateBreak"),
                 label = "unit",
@@ -70,30 +65,14 @@ mod_group_vol_time_server <- function(id, highlighted_dataframe, r) {
 
     group_vol_time_titles <- mod_reactive_labels_server("groupVolTimeTitles")
 
-    # get the minimum date range and store in a reactive
-    date_min <- reactive(min(highlighted_dataframe()[["date"]]))
-    date_max <- reactive(max(highlighted_dataframe()[["date"]]))
-
-    shiny::observe({
-      shiny::updateDateRangeInput(
-        session = session,
-        inputId = "dateRangeGroupVol",
-        start = date_min(),
-        end = date_max()
-      )
-    })
+    group_date_range_vot <- mod_daterange_input_server("dateRangeGroupVol", highlighted_dataframe, r)
 
     group_vol_time_reactive <- shiny::reactive({
       if (nrow(highlighted_dataframe()) < 1) {
         validate("You must select data first to view a grouped volume over time plot")
       }
 
-      group_vol_time_plot <- highlighted_dataframe() %>%
-        dplyr::filter(!!dplyr::sym(r$global_group_var) %in% r$current_subgroups) %>%
-        dplyr::filter(
-          date >= input$dateRangeGroupVol[[1]],
-          date <= input$dateRangeGroupVol[[2]]
-        ) %>%
+      group_vol_time_plot <- group_date_range_vot$over_time_data() %>%
         LandscapeR::ls_plot_group_vol_time(
           group_var = r$global_group_var,
           date_var = date,

--- a/R/mod_volume_over_time.R
+++ b/R/mod_volume_over_time.R
@@ -58,7 +58,7 @@ mod_volume_over_time_server <- function(id, highlighted_dataframe, r) {
 
     vol_titles <- mod_reactive_labels_server("volumeTitles")
 
-    date_range_vot <- mod_daterange_input_server("dateRangeVot", highlighted_dataframe = highlighted_dataframe, r = r)
+    date_range_vot <- mod_daterange_input_server("dateRangeVot", highlighted_dataframe = highlighted_dataframe, r = r) # Render the reactive plot from this.
 
     volume_reactive <- reactive({
       if (nrow(highlighted_dataframe()) < 1) {

--- a/R/mod_volume_over_time.R
+++ b/R/mod_volume_over_time.R
@@ -20,22 +20,29 @@ mod_volume_over_time_ui <- function(id, distribution_tab_height, distribution_ta
           shiny::tagList(
             shinyWidgets::noUiSliderInput(inputId = ns("height"), label = "height", min = 300, max = 1400, value = distribution_tab_height, step = 50, color = "#ff7518"),
             shinyWidgets::noUiSliderInput(inputId = ns("width"), label = "width", min = 300, max = 1400, value = distribution_tab_width, step = 50, color = "#ff7518"),
-            shiny::dateRangeInput(
-              inputId = ns("dateRange"),
-              label = "date range",
-              start = NULL,
-              end = NULL
-            ),
+            mod_daterange_input_ui(id = ns("dateRangeVot")),
+            # shiny::dateRangeInput(
+            #   inputId = ns("dateRangeVot"),
+            #   label = "date range",
+            #   start = NULL,
+            #   end = NULL,
+            #   max = Sys.Date() + 1,
+            #   min = Sys.Date() - (365*5)
+            #   # start = as.Date("2023-01-01"),
+            #   # end = Sys.Date() ,
+            #   # min = Sys.Date() - (365*3),
+            #   # max = Sys.Date() + 1
+            # ),
             shiny::selectInput(inputId = ns("dateBreak"), label = "unit", choices = c("day", "week", "month", "quarter", "year"), selected = "week"),
             shiny::selectInput(inputId = ns("dateSmooth"), label = "smooth", choices = c("none", "loess", "lm", "glm", "gam"), selected = "none"),
             shiny::uiOutput(ns("smoothControls")),
             colourpicker::colourInput(ns("volumeHex"), label = "colour", value = "#107C10"),
             mod_reactive_labels_ui(ns("volumeTitles")),
             shiny::downloadButton(outputId = ns("saveVolume"), class = "btn btn-warning")
-        )
+          )
         ),
-        # ... starts here and is the mainPanel
-          shinycssloaders::withSpinner(shiny::plotOutput(outputId = ns("volumePlot"), height = "450px", width = "450px"))
+        # ... of layout_sidebar() starts here and is the mainPanel
+        shinycssloaders::withSpinner(shiny::plotOutput(outputId = ns("volumePlot"), height = "450px", width = "450px"))
       )
     )
   )
@@ -45,43 +52,25 @@ mod_volume_over_time_ui <- function(id, distribution_tab_height, distribution_ta
 #' volume_over_time Server Functions
 #'
 #' @noRd
-mod_volume_over_time_server <- function(id, highlighted_dataframe) {
+mod_volume_over_time_server <- function(id, highlighted_dataframe, r) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
     vol_titles <- mod_reactive_labels_server("volumeTitles")
 
-    # get the minimum date range and store in a reactive
-    date_min <- reactive(min(highlighted_dataframe()[["date"]]))
-    date_max <- reactive(max(highlighted_dataframe()[["date"]]))
-
-
-    observe({
-      shiny::updateDateRangeInput(
-        session = session,
-        inputId = "dateRange", # Link to UI's dateRange
-        label = "date range",
-        start = date_min(), # ensure called reactively
-        end = date_max()
-      ) # ensure called reactively
-    })
+    date_range_vot <- mod_daterange_input_server("dateRangeVot", highlighted_dataframe = highlighted_dataframe, r = r)
 
     volume_reactive <- reactive({
       if (nrow(highlighted_dataframe()) < 1) {
         validate("You must select data first to view a volume over time plot")
       }
 
-      vol_plot <- highlighted_dataframe() %>%
-        dplyr::mutate(date = as.Date(date)) %>%
-        dplyr::filter(
-          date >= input$dateRange[[1]],
-          date <= input$dateRange[[2]]
-        ) %>%
+      vol_plot <- date_range_vot$over_time_data() %>%
         LandscapeR::ls_plot_volume_over_time(
           .date_var = date,
           unit = input$dateBreak,
           fill = delayedVolumeHex()
-        ) # Add the labels from mod_reactive_labels to the plot
+        )
 
       if (!input$dateSmooth == "none") {
         if (input$smoothSe == "FALSE") {
@@ -136,9 +125,9 @@ mod_volume_over_time_server <- function(id, highlighted_dataframe) {
       shiny::debounce(500)
 
     output$saveVolume <- LandscapeR::download_box("volume_plot",
-      volume_reactive,
-      width = shiny::reactive(input$width),
-      height = shiny::reactive(input$height)
+                                                  volume_reactive,
+                                                  width = shiny::reactive(input$width),
+                                                  height = shiny::reactive(input$height)
     )
   })
 }

--- a/app.R
+++ b/app.R
@@ -4,4 +4,4 @@
 
 pkgload::load_all(export_all = FALSE,helpers = FALSE,attach_testthat = FALSE)
 options( "golem.app.prod" = TRUE)
-LandscaperGolem::run_app() # add parameters here (if any)
+LandscapeRGolem::run_app() # add parameters here (if any)


### PR DESCRIPTION
Add fixes for https://github.com/jpcompartir/LandscaperGolem/issues/32

Summary:

move dateRangeInputs to a module - reduce duplication + better debugging - at the cost of a bit of NS() trickiness.
call the module from each of the tabs that have over time charts with dateRangeInputs/updateDateRangeInputs
filter the data frame inside these modules and return the module for the parent module to access that data

Still not sure on *what* changed to lead to the breaking changes, but this fix is better than original implementation.